### PR TITLE
Implement Ordering for Coffee Cards

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,6 +23,7 @@
         "react-cookie": "^7.1.0",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
+        "react-icons": "^5.0.1",
         "react-router-dom": "^6.22.2",
         "react-scripts": "^5.0.1",
         "react-toastify": "^10.0.4",
@@ -15657,6 +15658,14 @@
       },
       "peerDependencies": {
         "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "react-cookie": "^7.1.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
+    "react-icons": "^5.0.1",
     "react-router-dom": "^6.22.2",
     "react-scripts": "^5.0.1",
     "react-toastify": "^10.0.4",

--- a/client/src/helpers/Miscellaneous/sortCoffees.js
+++ b/client/src/helpers/Miscellaneous/sortCoffees.js
@@ -1,6 +1,6 @@
 import { calcRestDays } from 'helpers';
 
-function sortCoffees(coffees, key) {
+function sortCoffees(coffees, key, reverse = false) {
   let sortedData = [];
   if (key === 'restDays') {
     sortedData = [...coffees].sort((a, b) => {
@@ -28,6 +28,9 @@ function sortCoffees(coffees, key) {
       }
       return 0;
     });
+  }
+  if (reverse) {
+    sortedData.reverse();
   }
   return sortedData;
 }

--- a/client/src/pages/Dashboard/Dashboard.jsx
+++ b/client/src/pages/Dashboard/Dashboard.jsx
@@ -50,6 +50,7 @@ function Dashboard() {
   const [viewDialog, setViewDialog] = useState(false);
 
   let currentSort = useRef('creationDate');
+  let reverseSort = useRef(false);
   let duplicateDialog = useRef(false);
 
   const toggleViewDialog = (event, reason) => {
@@ -80,7 +81,7 @@ function Dashboard() {
     getAllCoffeeData().then((coffees) => {
       clearSearch();
       setAllCoffeeData(coffees);
-      setVisibleCoffeeData(sortCoffees(coffees, currentSort.current));
+      setVisibleCoffeeData(sortCoffees(coffees, currentSort.current, reverseSort.current));
       setIsLoadingData(false);
     });
   }, [clearSearch, currentSort]);
@@ -132,6 +133,7 @@ function Dashboard() {
             visibleCoffeeData={visibleCoffeeData}
             setVisibleCoffeeData={setVisibleCoffeeData}
             currentSort={currentSort}
+            reverseSort={reverseSort}
             sortCoffees={sortCoffees}
           />
           {isLoadingData ? (

--- a/client/src/pages/Dashboard/SearchSortPanel.jsx
+++ b/client/src/pages/Dashboard/SearchSortPanel.jsx
@@ -1,11 +1,13 @@
-import { Grid, TextField, MenuItem } from '@mui/material';
 import { useRef } from 'react';
+import { Grid, TextField, MenuItem, Button } from '@mui/material';
+import { BiSortDown, BiSortUp } from 'react-icons/bi';
 
 function SearchSortPanel({
   allCoffeeData,
   visibleCoffeeData,
   setVisibleCoffeeData,
   currentSort,
+  reverseSort,
   sortCoffees,
 }) {
   let searchBy = useRef('all');
@@ -40,7 +42,7 @@ function SearchSortPanel({
         coffee[searchBy.current].toLowerCase().includes(value.toLowerCase())
       );
     }
-    setVisibleCoffeeData(sortCoffees(searchResults, currentSort.current));
+    setVisibleCoffeeData(sortCoffees(searchResults, currentSort.current, reverseSort.current));
   };
 
   const sortOptions = [
@@ -54,7 +56,12 @@ function SearchSortPanel({
 
   const handleSort = (key) => {
     currentSort.current = key;
-    setVisibleCoffeeData(sortCoffees(visibleCoffeeData, key));
+    setVisibleCoffeeData(sortCoffees(visibleCoffeeData, key, reverseSort.current));
+  };
+
+  const handleOrder = () => {
+    reverseSort.current = !reverseSort.current;
+    setVisibleCoffeeData(sortCoffees(visibleCoffeeData, currentSort.current, reverseSort.current));
   };
 
   return (
@@ -104,6 +111,16 @@ function SearchSortPanel({
             </MenuItem>
           ))}
         </TextField>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleOrder}
+          sx={{
+            margin: '0 0 0 0.5rem',
+          }}
+        >
+          {reverseSort.current ? <BiSortDown size={24} /> : <BiSortUp size={24} />}
+        </Button>
       </Grid>
     </Grid>
   );

--- a/client/src/pages/Dashboard/SearchSortPanel.jsx
+++ b/client/src/pages/Dashboard/SearchSortPanel.jsx
@@ -112,6 +112,7 @@ function SearchSortPanel({
           ))}
         </TextField>
         <Button
+          aria-label="order"
           variant="contained"
           color="primary"
           onClick={handleOrder}


### PR DESCRIPTION
## Description

This pull request introduces a feature into RoastRest that allows users to toggle the order of coffee cards between ascending and descending by pressing an ordering button on the dashboard. Ths feature enhances user experience and provides better usability by helping them view and find relevant coffee logs more efficiently.