### PR TITLE
Implement Freeze/Unfreeze Menu Item for Coffee Cards

### DIFF
--- a/client/src/helpers/Coffee/toggleCoffeeFrozen.js
+++ b/client/src/helpers/Coffee/toggleCoffeeFrozen.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import { isFrozen } from '..';
+
+function toggleCoffeeFrozen(coffeeId, frozenStart, frozenEnd) {
+  const frozen = isFrozen(frozenStart, frozenEnd);
+  const currentDate = new Date().setHours(13, 0, 0, 0);
+
+  if (frozen) {
+    return axios.put(`/coffee/${coffeeId}`, { frozenEnd: currentDate }, { withCredentials: true });
+  } else {
+    return axios.put(
+      `/coffee/${coffeeId}`,
+      { frozenStart: currentDate },
+      { withCredentials: true }
+    );
+  }
+}
+
+export default toggleCoffeeFrozen;

--- a/client/src/helpers/index.js
+++ b/client/src/helpers/index.js
@@ -11,6 +11,7 @@ export { default as deleteCoffeeData } from './Coffee/deleteCoffeeData';
 export { default as calcRemainingDoses } from './Coffee/calcRemainingDoses';
 export { default as useCoffeeDose } from './Coffee/useCoffeeDose';
 export { default as isFrozen } from './Coffee/isFrozen';
+export { default as toggleCoffeeFrozen } from './Coffee/toggleCoffeeFrozen';
 export { default as toggleCoffeePin } from './Coffee/toggleCoffeePin';
 export { default as parseDateToISO } from './Miscellaneous/parseDateToISO';
 export { default as toTitleCase } from './Miscellaneous/toTitleCase';

--- a/client/src/pages/Dashboard/CoffeeCard/CoffeeCardMenu.jsx
+++ b/client/src/pages/Dashboard/CoffeeCard/CoffeeCardMenu.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { MoreVert, PushPinOutlined, ContentCopy, DeleteOutline } from '@mui/icons-material';
+import { MoreVert, AcUnit, PushPinOutlined, ContentCopy, DeleteOutline } from '@mui/icons-material';
 import { IconButton, Menu, MenuItem, ListItemIcon } from '@mui/material';
-import { toggleCoffeePin, deleteCoffeeData } from 'helpers';
+import { toggleCoffeePin, toggleCoffeeFrozen, deleteCoffeeData } from 'helpers';
 
 function CoffeeCardMenu({ coffeeData, updateData, duplicateData }) {
   const [anchorEl, setAnchorEl] = useState(null);
@@ -12,6 +12,13 @@ function CoffeeCardMenu({ coffeeData, updateData, duplicateData }) {
 
   const handleClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleFrozen = () => {
+    toggleCoffeeFrozen(coffeeData._id, coffeeData.frozenStart, coffeeData.frozenEnd).then(() => {
+      updateData();
+    });
+    handleClose();
   };
 
   const handlePin = () => {
@@ -60,6 +67,12 @@ function CoffeeCardMenu({ coffeeData, updateData, duplicateData }) {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
+        <MenuItem onClick={handleFrozen}>
+          <ListItemIcon>
+            <AcUnit fontSize="small" />
+          </ListItemIcon>
+          {coffeeData.frozenStart ? 'Unfreeze' : 'Freeze'}
+        </MenuItem>
         <MenuItem onClick={handlePin}>
           <ListItemIcon>
             <PushPinOutlined fontSize="small" />

--- a/client/src/pages/Dashboard/CoffeeCard/CoffeeCardMenu.jsx
+++ b/client/src/pages/Dashboard/CoffeeCard/CoffeeCardMenu.jsx
@@ -67,6 +67,12 @@ function CoffeeCardMenu({ coffeeData, updateData, duplicateData }) {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
+        <MenuItem onClick={handlePin}>
+          <ListItemIcon>
+            <PushPinOutlined fontSize="small" />
+          </ListItemIcon>
+          {coffeeData.isPinned ? 'Unpin' : 'Pin'}
+        </MenuItem>
         {coffeeData.frozenStart && coffeeData.frozenEnd ? null : (
           <MenuItem onClick={handleFrozen}>
             <ListItemIcon>
@@ -75,12 +81,6 @@ function CoffeeCardMenu({ coffeeData, updateData, duplicateData }) {
             {coffeeData.frozenStart ? 'Unfreeze' : 'Freeze'}
           </MenuItem>
         )}
-        <MenuItem onClick={handlePin}>
-          <ListItemIcon>
-            <PushPinOutlined fontSize="small" />
-          </ListItemIcon>
-          {coffeeData.isPinned ? 'Unpin' : 'Pin'}
-        </MenuItem>
         <MenuItem onClick={handleDuplicate}>
           <ListItemIcon>
             <ContentCopy fontSize="small" />

--- a/client/src/pages/Dashboard/CoffeeCard/CoffeeCardMenu.jsx
+++ b/client/src/pages/Dashboard/CoffeeCard/CoffeeCardMenu.jsx
@@ -67,12 +67,14 @@ function CoffeeCardMenu({ coffeeData, updateData, duplicateData }) {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        <MenuItem onClick={handleFrozen}>
-          <ListItemIcon>
-            <AcUnit fontSize="small" />
-          </ListItemIcon>
-          {coffeeData.frozenStart ? 'Unfreeze' : 'Freeze'}
-        </MenuItem>
+        {coffeeData.frozenStart && coffeeData.frozenEnd ? null : (
+          <MenuItem onClick={handleFrozen}>
+            <ListItemIcon>
+              <AcUnit fontSize="small" />
+            </ListItemIcon>
+            {coffeeData.frozenStart ? 'Unfreeze' : 'Freeze'}
+          </MenuItem>
+        )}
         <MenuItem onClick={handlePin}>
           <ListItemIcon>
             <PushPinOutlined fontSize="small" />


### PR DESCRIPTION
## Description

This pull request introduces a feature into RoastRest that allows users to freeze and unfreeze coffee logs much easier, through a new menu item. This feature enhances user experience and provides better usability by providing a shortcut to freezing and unfreezing logs, which previously required users to manually specify the current date.